### PR TITLE
Make group fields accessible

### DIFF
--- a/dhgroup.go
+++ b/dhgroup.go
@@ -29,6 +29,14 @@ type DHGroup struct {
 	g *big.Int
 }
 
+func (self *DHGroup) P() *big.Int {
+	return self.p
+}
+
+func (self *DHGroup) G() *big.Int {
+	return self.g
+}
+
 func (self *DHGroup) GeneratePrivateKey(randReader io.Reader) (key *DHKey, err error) {
 	if randReader == nil {
 		randReader = rand.Reader


### PR DESCRIPTION
Hey, I'm currently working on a Go DTLS implementation, and I needed to be able to read the fields of the group. However, I would like to avoid to many forks, do you think this is something you can merge?