### PR TITLE
Make `P()` and `G()` return copied `big.Int`s so they can't be mutated

### DIFF
--- a/dhgroup.go
+++ b/dhgroup.go
@@ -30,11 +30,15 @@ type DHGroup struct {
 }
 
 func (self *DHGroup) P() *big.Int {
-	return self.p
+	p := new(big.Int)
+	p.Set(self.p)
+	return p
 }
 
 func (self *DHGroup) G() *big.Int {
-	return self.g
+	g := new(big.Int)
+	g.Set(self.g)
+	return g
 }
 
 func (self *DHGroup) GeneratePrivateKey(randReader io.Reader) (key *DHKey, err error) {

--- a/dhkx_test.go
+++ b/dhkx_test.go
@@ -101,3 +101,21 @@ func TestCustomGroupKeyExchange(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 }
+
+func TestPIsNotMutable(t *testing.T) {
+	d, _ := GetGroup(0)
+	p := d.p.String()
+	d.P().Set(big.NewInt(1))
+	if p != d.p.String() {
+		t.Errorf("group's prime mutated externally, should be %s, was changed to %s", p, d.p.String())
+	}
+}
+
+func TestGIsNotMutable(t *testing.T) {
+	d, _ := GetGroup(0)
+	g := d.g.String()
+	d.G().Set(big.NewInt(0))
+	if g != d.g.String() {
+		t.Errorf("group's generator mutated externally, should be %s, was changed to %s", g, d.g.String())
+	}
+}


### PR DESCRIPTION
[This pull request][PR4] accidentally introduced an external mutation issue to `DHGroup`. E.g.

    d.P().Set(big.NewInt(1))

would actually mutate the value within the `DHGroup`, `d`, with potentially disastrous consequences.

This PR resolves this issue by returning a newly allocated `big.Int` from `P()` and `G()` and adds tests for accidental mutation of P or G.

[PR4]: https://github.com/monnand/dhkx/pull/4